### PR TITLE
Change VCF description in Input formats and add link to VCF format 4.1 and 4.2

### DIFF
--- a/mutspecAnnot.xml
+++ b/mutspecAnnot.xml
@@ -72,7 +72,10 @@ The tool supports different column names (**names are case-sensitive**) dependin
 
 **mutect** :     contig position ref_allele alt_allele
 
-**vcf** :        CHROM POS REF ALT
+**vcf** :        version `4.1`__ and `4.2`__
+
+.. __: https://samtools.github.io/hts-specs/VCFv4.1.pdf
+.. __: https://samtools.github.io/hts-specs/VCFv4.2.pdf
 
 **cosmic** :     Mutation_GRCh37_chromosome_number Mutation_GRCh37_genome_position Description_Ref_Genomic Description_Alt_Genomic
 


### PR DESCRIPTION
For VCF file only format 4.1 and 4.2 are recognise by MutSpec-Annot